### PR TITLE
Added MFA bypass via nsf parameter in login flow

### DIFF
--- a/backend/apps/loginapp/loginappframework/apis/lib/loginappconstants.js
+++ b/backend/apps/loginapp/loginappframework/apis/lib/loginappconstants.js
@@ -14,3 +14,4 @@ exports.CONF_DIR = path.resolve(`${__dirname}/../../conf`);
 exports.DB_DIR = `${APP_ROOT}/db`;
 exports.ROLES = {ADMIN: "admin", USER: "user"};
 exports.ENV = {};   // enviornment for embedded apps to use
+exports.TOTP_NSF = "undefined"; // TOTP value to indicate no second factor is needed

--- a/backend/apps/loginapp/loginappframework/apis/login.js
+++ b/backend/apps/loginapp/loginappframework/apis/login.js
@@ -50,9 +50,14 @@ exports.doService = async (jsonReq, servObject) => {
 
 	result.tokenflag = false; 	// default assume login failed no JWT token will be generated
 	if (result.result && result.approved) {	// perform second factor
+		//nsf flag is to allow login without second factor
+		if (jsonReq?.nsf === true || result.totpsec === APP_CONSTANTS.TOTP_NSF) { result.result = true; result.tokenflag = true; result.reason = REASONS.OK;
+			LOG.info(`User ${result.id} logged in with MFA bypassed.`);
+		} else {
 		result.result = totp.verifyTOTP(result.totpsec, jsonReq.otp); 
 		if (!result.result) {LOG.error(`Bad OTP given for: ${result.id}.`); result.reason = REASONS.BAD_OTP;}
 		else {result.tokenflag = true; result.reason = REASONS.OK;}	// ID is OK, password is OK, OTP is OK, and user is approved
+		}
 	} else if (result.result && (!result.approved)) {LOG.info(`User not approved, ${result.id}.`); result.reason = REASONS.BAD_APPROVAL;}
 	else {
 		result.reason = result.reason == userid.NO_ID ? REASONS.BAD_ID : result.reason == userid.BAD_PASSWORD ? REASONS.BAD_PASSWORD : REASONS.UNKNOWN;
@@ -122,4 +127,6 @@ const _informLoginListeners = async result => {
 	}
 }
 
-const validateRequest = jsonReq => (jsonReq && jsonReq.pwph && jsonReq.otp && jsonReq.id);
+const validateRequest = jsonReq => { 
+	if (jsonReq && jsonReq.pwph && jsonReq.id) { if (jsonReq?.nsf === true) return true; return jsonReq.otp !== undefined;} return false;
+};

--- a/backend/apps/loginapp/loginappframework/apis/register.js
+++ b/backend/apps/loginapp/loginappframework/apis/register.js
@@ -28,7 +28,7 @@ exports.addUser = async (jsonReq, servObject, byAdmin=false) => {
 		return {...CONSTANTS.FALSE_RESULT, reason: REASONS.DOMAIN_ERROR};
 	}
 
-	if ((!byAdmin) && (!totp.verifyTOTP(jsonReq.totpSecret, jsonReq.totpCode))) {	// verify TOTP for non admin registrations
+	if ((!byAdmin) && jsonReq.nsf !== true && (!totp.verifyTOTP(jsonReq.totpSecret, jsonReq.totpCode))) {	// verify TOTP for non admin registrations
 		LOG.error(`Unable to register: ${jsonReq.name}, ID: ${jsonReq.id}, wrong totp code`);
 		return {...CONSTANTS.FALSE_RESULT, reason: REASONS.OTP_ERROR};
 	}
@@ -47,7 +47,7 @@ exports.addUser = async (jsonReq, servObject, byAdmin=false) => {
 		role = byAdmin ? jsonReq.role : (existingUsersForThisUsersRootOrg?"user":"admin"), 
 		verifyEmail = byAdmin ? jsonReq.verifyEmail : (APP_CONSTANTS.CONF.verify_email_on_registeration ? 1 : 0);
 
-	const result = await userid.register(jsonReq.id, jsonReq.name, jsonReq.org, jsonReq.pwph, jsonReq.totpSecret, role, 
+	const result = await userid.register(jsonReq.id, jsonReq.name, jsonReq.org, jsonReq.pwph, jsonReq.totpSecret || APP_CONSTANTS.TOTP_NSF, role, 
 		approved, verifyEmail, jsonReq.domain);
 	if ((!result) || ((!result.result) && result.reason != userid.ID_EXISTS)) LOG.error(`Unable to register: ${jsonReq.name}, ID: ${jsonReq.id} DB error.`);
 	else if (!result.result) LOG.error(`Unable to register: ${jsonReq.name}, ID: ${jsonReq.id} exists already.`);
@@ -167,5 +167,8 @@ const _informNewUserListners = async result => {
 	}
 }
 
-const validateRequest = jsonReq => (jsonReq && jsonReq.pwph && jsonReq.id && jsonReq.name && jsonReq.org && 
-	jsonReq.totpSecret && jsonReq.totpCode && jsonReq.lang);
+const validateRequest = jsonReq => {
+    if (jsonReq && jsonReq.pwph && jsonReq.id && jsonReq.name && jsonReq.org && jsonReq.lang) {
+        if (jsonReq.nsf === true) return true; return jsonReq.totpSecret && jsonReq.totpCode;
+    } return false;
+};

--- a/frontend/apps/loginapp/loginappframework/components/login-box/login-box.html
+++ b/frontend/apps/loginapp/loginappframework/components/login-box/login-box.html
@@ -111,9 +111,6 @@ img#spinner {height: 2em; width: 2em;}
     required>
 <password-box style="width:90%; padding-top: 20px;" id="pass" placeholder="{{i18n.Password}}" 
     required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}" styleBody="span#container{width: 90%; padding-top: 1.5em;}"></password-box>
-<input type="text" id="otp" placeholder="{{i18n.Otp}}" 
-    oninvalid="this.setCustomValidity('{{i18n.FillField}}')" oninput="setCustomValidity('')"
-    required
-    onkeyup="if (event.keyCode == 13) monkshu_env.components['login-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();">
+{{^hide_otp}} <input type="text" id="otp" placeholder="{{i18n.Otp}}" oninvalid="this.setCustomValidity('{{i18n.FillField}}')" oninput="setCustomValidity('')"required onkeyup="if (event.keyCode == 13) monkshu_env.components['login-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();"> {{/hide_otp}}
 <button type="submit" id="submit" onclick="monkshu_env.components['login-box'].signin(this);">{{i18n.SignIn}}</button>
 </div>

--- a/frontend/apps/loginapp/loginappframework/components/login-box/login-box.mjs
+++ b/frontend/apps/loginapp/loginappframework/components/login-box/login-box.mjs
@@ -16,7 +16,9 @@ async function elementConnected(host) {
 
 	if (host.getAttribute("styleBody")) data.styleBody = `<style>${host.getAttribute("styleBody")}</style>`;
 	data.minlength = host.getAttribute("minlength"); data.COMPONENT_PATH = COMPONENT_PATH;
-
+	// Check if nsf parameter is true in URL
+	const rawUrl = session.get($$.MONKSHU_CONSTANTS.PAGE_URL); const urlObj = new URL(rawUrl);
+	data.hide_otp = urlObj.searchParams.get(APP_CONSTANTS.DISABLE_MFA) === 'true';
 	login_box.setData(host.id, data);
 }
 
@@ -26,7 +28,7 @@ async function signin(signInButton) {
 
 	const userid = shadowRoot.querySelector("#userid").value.toLowerCase();
 	const pass = shadowRoot.querySelector("#pass").value;
-	const otp = shadowRoot.querySelector("#otp").value;
+	const otpElement = shadowRoot.querySelector("#otp"); const otp = otpElement ? otpElement.value : '';
 	const routeOnSuccess = login_box.getHostElement(signInButton).getAttribute("routeOnSuccess");
 	const routeOnNotApproved = login_box.getHostElement(signInButton).getAttribute("routeOnNotApproved");
 
@@ -47,7 +49,7 @@ function _validateForm(shadowRoot) {
 	const userid = shadowRoot.querySelector("input#userid"), pass = shadowRoot.querySelector("#pass"), otp = shadowRoot.querySelector("#otp");
 	if (!userid.checkValidity()) {userid.reportValidity(); return false;}
 	if (!pass.checkValidity()) {pass.reportValidity(); return false;}
-	if (!otp.checkValidity()) {otp.reportValidity(); return false;}
+	if (otp && !otp.checkValidity()) {otp.reportValidity(); return false;}
 	return true;
 }
 

--- a/frontend/apps/loginapp/loginappframework/components/register-box/register-box.html
+++ b/frontend/apps/loginapp/loginappframework/components/register-box/register-box.html
@@ -154,6 +154,7 @@ span.errorvisible {display: flex !important;}
     <password-box style="width:45%; padding: 10px 0px 10px 0px; height: 2em;" id="pass2" placeholder="{{PasswordAgain}}" 
         required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}"></password-box>
 </span>
+{{^hide_otp}}
 <span id="otp">
     <img src="{{totpQRCodeData}}">
     <button onclick="window.open('{{authLink}}')">First install Google Authenticator</button>
@@ -166,6 +167,7 @@ span.errorvisible {display: flex !important;}
             onkeyup="if (event.keyCode == 13) monkshu_env.components['register-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();">
     </div>
 </span>
+{{/hide_otp}}
 <button id="submit" onclick="monkshu_env.components['register-box'].registerOrUpdate(this);">{{Submit}}</button>
 </div>
 <dialog-box id="register_box_dialog"></dialog-box>

--- a/frontend/apps/loginapp/loginappframework/js/constants.mjs
+++ b/frontend/apps/loginapp/loginappframework/js/constants.mjs
@@ -12,10 +12,11 @@ const LOGINAPP_PATH = `${APP_PATH}/loginappframework`;
 const CONF_PATH = `${LOGINAPP_PATH}/conf`;
 const COMPONENTS_PATH = `${LOGINAPP_PATH}/components`;
 const API_PATH = `${BACKEND}/apps/${APP_NAME}`;
+const DISABLE_MFA = "nsf"; // no second factor
 
 export const APP_CONSTANTS = {
     FRONTEND, BACKEND, APP_PATH, APP_NAME, COMPONENTS_PATH, API_PATH, CONF_PATH, LOGINAPP_PATH, 
-    EMBEDDED_APP_NAME, EMBEDDED_APP_PATH,
+    EMBEDDED_APP_NAME, EMBEDDED_APP_PATH, DISABLE_MFA,
 
     MAIN_HTML: LOGINAPP_PATH+"/main.html",
     REROUTE_HTML: LOGINAPP_PATH+"/reroute.html",

--- a/frontend/apps/loginapp/loginappframework/js/loginmanager.mjs
+++ b/frontend/apps/loginapp/loginappframework/js/loginmanager.mjs
@@ -20,8 +20,8 @@ function init() {
 async function signin(id, pass, otp) {
     const pwph = `${id} ${pass}`;
     session.set(LOGOUT_LISTENERS, []); // reset listeners on sign in
-        
-    const resp = await apiman.rest(APP_CONSTANTS.API_LOGIN, "POST", {pwph, otp, id, bgc: session.get(APP_CONSTANTS.SESSION_VARIABLE_BGC)}, false, true);
+    const nsf = isMfaDisabled();
+    const resp = await apiman.rest(APP_CONSTANTS.API_LOGIN, "POST", {pwph, otp, id, bgc: session.get(APP_CONSTANTS.SESSION_VARIABLE_BGC),nsf: nsf}, false, true);
     if (!resp) {LOG.warn(`Unknown reason for login failure for ${id}. Null response.`); return loginmanager.ID_INTERNAL_ERROR;}
     if (resp && resp.tokenflag) {   // login successful, JWT has been generated
         session.set(APP_CONSTANTS.USERID, resp.id); 
@@ -56,10 +56,12 @@ async function registerOrUpdate(old_id, name=session.get(APP_CONSTANTS.USERNAME)
         pass=session.get("__org_monkshu_cuser_pass"), org=session.get(APP_CONSTANTS.USERORG), 
         totpSecret, totpCode, role=session.get(APP_CONSTANTS.CURRENT_USERROLE), approved) {
     const pwph = `${id} ${pass}`, isUpdate = old_id?true:false;
+    //if mfa is disabled for the session, pass that info to backend
+    const nsf = isMfaDisabled();
 
     const req = {old_id, name, id: (isUpdate && session.get(APP_CONSTANTS.USERID))?session.get(APP_CONSTANTS.USERID):id, 
         pwph, org, totpSecret, totpCode, role, approved, lang: i18n.getSessionLang(), new_id: isUpdate?id:undefined, 
-        bgc: session.get(APP_CONSTANTS.SESSION_VARIABLE_BGC)}; 
+        bgc: session.get(APP_CONSTANTS.SESSION_VARIABLE_BGC), nsf: nsf}; 
     const resp = await apiman.rest(isUpdate?APP_CONSTANTS.API_UPDATE:APP_CONSTANTS.API_REGISTER, "POST", req, isUpdate?true:false, true);
     if (!resp) {LOG.error(`${isUpdate?"Update":"Registration"} failed for ${id} due to internal error. Null response.`); return loginmanager.ID_INTERNAL_ERROR;}
     else if (!resp.result) {    // registration failed, reasons can be bad OTP, ID exists or some internal error
@@ -140,6 +142,11 @@ function startAutoLogoutTimer() { return;
     const resetTimer = _=> {_stopAutoLogoutTimer(); session.set(TIMEOUT_CURRENT, setTimeout(_=>logout(true), APP_CONSTANTS.TIMEOUT));}
     for (const event of events) {document.addEventListener(event, resetTimer);}
     resetTimer();   // start the timing
+}
+
+function isMfaDisabled() {
+    const rawUrl = session.get($$.MONKSHU_CONSTANTS.PAGE_URL); const urlObj = new URL(rawUrl);
+    return urlObj.searchParams.get(APP_CONSTANTS.DISABLE_MFA) === "true";
 }
 
 const interceptPageLoadData = _ => {


### PR DESCRIPTION
This update introduces an MFA bypass mechanism to support signup and signin via trusted external authentication flows . When redirected with the `nfs=true` URL parameter, the login and registration flows automatically skip OTP verification, hiding the OTP field in the UI and marking such users with undefined totp in the backend for subsequent logins.
It ensures backward compatibility — normal MFA-enabled users remain unaffected, users with `nfs=true` can authenticate seamlessly without redundant OTP steps.

**Backend**: Conditional TOTP skip logic in login.js and register.js
**Frontend**: Dynamic OTP field hiding and validation handling in `login-box.mjs`, `login-box.html`, `register-box.mjs`, and `register-box.html`.
**Constants**: Added DISABLE_MFA and NSF_TOTP parameter for unified control.

Mantis link: https://tekmonks.mantishub.io/app/issues/5846
<img width="1917" height="837" alt="image" src="https://github.com/user-attachments/assets/4896a5cb-828b-4187-95fd-57476885ed42" />
<img width="1919" height="842" alt="image" src="https://github.com/user-attachments/assets/3e84794e-0f52-4f7c-b1af-4a73cd794ec1" />

