### PR TITLE
Added MFA bypass in login flow

### DIFF
--- a/backend/apps/loginapp/loginappframework/apis/lib/loginappconstants.js
+++ b/backend/apps/loginapp/loginappframework/apis/lib/loginappconstants.js
@@ -14,3 +14,4 @@ exports.CONF_DIR = path.resolve(`${__dirname}/../../conf`);
 exports.DB_DIR = `${APP_ROOT}/db`;
 exports.ROLES = {ADMIN: "admin", USER: "user"};
 exports.ENV = {};   // enviornment for embedded apps to use
+exports.TOTP_BYPASS_FLAG = "undefined"; // TOTP value to bypass MFA

--- a/frontend/apps/loginapp/loginappframework/components/login-box/login-box.html
+++ b/frontend/apps/loginapp/loginappframework/components/login-box/login-box.html
@@ -110,10 +110,8 @@ img#spinner {height: 2em; width: 2em;}
     oninvalid="this.setCustomValidity('{{i18n.FillField}}')" oninput="setCustomValidity('')"
     required>
 <password-box style="width:90%; padding-top: 20px;" id="pass" placeholder="{{i18n.Password}}" 
-    required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}" styleBody="span#container{width: 90%; padding-top: 1.5em;}"></password-box>
-<input type="text" id="otp" placeholder="{{i18n.Otp}}" 
-    oninvalid="this.setCustomValidity('{{i18n.FillField}}')" oninput="setCustomValidity('')"
-    required
-    onkeyup="if (event.keyCode == 13) monkshu_env.components['login-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();">
+    required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}" styleBody="span#container{width: 90%; padding-top: 1.5em;}"
+    {{#hide_otp}}onkeyup="if (event.keyCode == 13) monkshu_env.components['login-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();"{{/hide_otp}}></password-box>
+{{^hide_otp}} <input type="text" id="otp" placeholder="{{i18n.Otp}}" oninvalid="this.setCustomValidity('{{i18n.FillField}}')" oninput="setCustomValidity('')"required onkeyup="if (event.keyCode == 13) monkshu_env.components['login-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();"> {{/hide_otp}}
 <button type="submit" id="submit" onclick="monkshu_env.components['login-box'].signin(this);">{{i18n.SignIn}}</button>
 </div>

--- a/frontend/apps/loginapp/loginappframework/components/login-box/login-box.mjs
+++ b/frontend/apps/loginapp/loginappframework/components/login-box/login-box.mjs
@@ -16,7 +16,9 @@ async function elementConnected(host) {
 
 	if (host.getAttribute("styleBody")) data.styleBody = `<style>${host.getAttribute("styleBody")}</style>`;
 	data.minlength = host.getAttribute("minlength"); data.COMPONENT_PATH = COMPONENT_PATH;
-
+	// Check if disable multi-factor authentication (dma) parameter is true in URL
+	const rawUrl = session.get($$.MONKSHU_CONSTANTS.PAGE_URL); const urlObj = new URL(rawUrl);
+	data.hide_otp = urlObj.searchParams.get(APP_CONSTANTS.DISABLE_MFA) === 'true';
 	login_box.setData(host.id, data);
 }
 
@@ -26,7 +28,7 @@ async function signin(signInButton) {
 
 	const userid = shadowRoot.querySelector("#userid").value.toLowerCase();
 	const pass = shadowRoot.querySelector("#pass").value;
-	const otp = shadowRoot.querySelector("#otp").value;
+	const otpElement = shadowRoot.querySelector("#otp"); const otp = otpElement ? otpElement.value : '';
 	const routeOnSuccess = login_box.getHostElement(signInButton).getAttribute("routeOnSuccess");
 	const routeOnNotApproved = login_box.getHostElement(signInButton).getAttribute("routeOnNotApproved");
 
@@ -47,7 +49,7 @@ function _validateForm(shadowRoot) {
 	const userid = shadowRoot.querySelector("input#userid"), pass = shadowRoot.querySelector("#pass"), otp = shadowRoot.querySelector("#otp");
 	if (!userid.checkValidity()) {userid.reportValidity(); return false;}
 	if (!pass.checkValidity()) {pass.reportValidity(); return false;}
-	if (!otp.checkValidity()) {otp.reportValidity(); return false;}
+	if (otp && !otp.checkValidity()) {otp.reportValidity(); return false;}
 	return true;
 }
 

--- a/frontend/apps/loginapp/loginappframework/components/register-box/register-box.html
+++ b/frontend/apps/loginapp/loginappframework/components/register-box/register-box.html
@@ -152,8 +152,10 @@ span.errorvisible {display: flex !important;}
     <password-box style="width:45%; padding: 10px 0px 10px 0px; height: 2em;" id="pass1" placeholder="{{Password}}" 
         required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}"></password-box>
     <password-box style="width:45%; padding: 10px 0px 10px 0px; height: 2em;" id="pass2" placeholder="{{PasswordAgain}}" 
-        required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}"></password-box>
+        required="true" minlength="{{minlength}}" customValidity="{{i18n.FillField}}"
+        {{#hide_otp}}onkeyup="if (event.keyCode == 13) monkshu_env.components['register-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();"{{/hide_otp}}></password-box>
 </span>
+{{^hide_otp}}
 <span id="otp">
     <img src="{{totpQRCodeData}}">
     <button onclick="window.open('{{authLink}}')">First install Google Authenticator</button>
@@ -166,6 +168,7 @@ span.errorvisible {display: flex !important;}
             onkeyup="if (event.keyCode == 13) monkshu_env.components['register-box'].getShadowRootByContainedElement(this).querySelector('#submit').click();">
     </div>
 </span>
+{{/hide_otp}}
 <button id="submit" onclick="monkshu_env.components['register-box'].registerOrUpdate(this);">{{Submit}}</button>
 </div>
 <dialog-box id="register_box_dialog"></dialog-box>

--- a/frontend/apps/loginapp/loginappframework/js/constants.mjs
+++ b/frontend/apps/loginapp/loginappframework/js/constants.mjs
@@ -12,10 +12,11 @@ const LOGINAPP_PATH = `${APP_PATH}/loginappframework`;
 const CONF_PATH = `${LOGINAPP_PATH}/conf`;
 const COMPONENTS_PATH = `${LOGINAPP_PATH}/components`;
 const API_PATH = `${BACKEND}/apps/${APP_NAME}`;
+const DISABLE_MFA = "dma"; // no second factor
 
 export const APP_CONSTANTS = {
     FRONTEND, BACKEND, APP_PATH, APP_NAME, COMPONENTS_PATH, API_PATH, CONF_PATH, LOGINAPP_PATH, 
-    EMBEDDED_APP_NAME, EMBEDDED_APP_PATH,
+    EMBEDDED_APP_NAME, EMBEDDED_APP_PATH, DISABLE_MFA,
 
     MAIN_HTML: LOGINAPP_PATH+"/main.html",
     REROUTE_HTML: LOGINAPP_PATH+"/reroute.html",


### PR DESCRIPTION
This update introduces an MFA bypass mechanism to support signup and signin via trusted external authentication flows . When redirected with the nfs=true URL parameter, the login and registration flows automatically skip OTP verification, hiding the OTP field in the UI and marking such users with undefined totp in the backend for subsequent logins.
It ensures backward compatibility — normal MFA-enabled users remain unaffected, users with nfs=true can authenticate seamlessly without redundant OTP steps.

Backend: Conditional TOTP skip logic in login.js and register.js
Frontend: Dynamic OTP field hiding and validation handling in login-box.mjs, login-box.html, register-box.mjs, and register-box.html.
Constants: Added DISABLE_MFA and NSF_TOTP parameter for unified control.

Mantis link: https://tekmonks.mantishub.io/app/issues/5846
<img width="1917" height="837" alt="image" src="https://github.com/user-attachments/assets/511a4eb3-f77b-4b65-9f32-594bb528e5ce" />
<img width="1919" height="842" alt="image" src="https://github.com/user-attachments/assets/66da0441-3869-41be-bb03-5edf1edcbb25" />
