### PR TITLE
[FIX] Replace undefined ENV with empty object for loginapp initialization

### DIFF
--- a/frontend/apps/loginapp/loginappframework/js/application.mjs
+++ b/frontend/apps/loginapp/loginappframework/js/application.mjs
@@ -11,7 +11,7 @@ import {APP_CONSTANTS as AUTO_APP_CONSTANTS} from "./constants.mjs";
 const apiman = $$.libapimanager;
 
 const init = async hostname => {
-	window.monkshu_env.apps[AUTO_APP_CONSTANTS.APP_NAME] = AUTO_APP_CONSTANTS.ENV;
+	window.monkshu_env.apps[AUTO_APP_CONSTANTS.APP_NAME] = {};
 	const mustache = await $$.librouter.getMustache();
 	window.APP_CONSTANTS = JSON.parse(mustache.render(JSON.stringify(AUTO_APP_CONSTANTS), {hostname}));
 	window.LOG = (await import ("/framework/js/log.mjs")).LOG;


### PR DESCRIPTION
**Root Cause:**
- application.mjs initialized window.monkshu_env.apps[APP_NAME] with AUTO_APP_CONSTANTS.ENV (which is undefined) instead of {}, causing post-login frontend runtime failures.

**Testing Done:**
- Logout button is working now.
- Initializing monkshu_env app namespace correctly.

**Previous:** (Not working when we click on logout button)
<img width="1835" height="944" alt="Before" src="https://github.com/user-attachments/assets/27461ae8-6175-4a93-9383-6dca2c784ea3" />

**After Fix:** (Logout perfectly)
<img width="1835" height="947" alt="AfterFix" src="https://github.com/user-attachments/assets/0597126d-8ff0-4de8-9038-fe7758419d32" />

**Mantis Link:** https://tekmonks.mantishub.io/app/issues/6010