### PR TITLE
[FIX]: permission map regex and checksec_immediate for latest Monkshu compatibility

### DIFF
--- a/backend/apps/loginapp/conf/apiregistry.json
+++ b/backend/apps/loginapp/conf/apiregistry.json
@@ -9,10 +9,10 @@
     "/apps/{{app}}/validatejwt" : "/loginappframework/apis/validatejwt.js?get=true",
     "/apps/{{app}}/resetuser" : "/loginappframework/apis/resetuser.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=false",
     "/apps/{{app}}/register" : "/loginappframework/apis/register.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=false&addsToken=sub:{{{role}}},tokenflag:{{{tokenflag}}},id:{{{id}}},org:{{{org}}}",
-    "/apps/{{app}}/adduserbyadmin" : "/loginappframework/apis/adduserbyadmin.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
-    "/apps/{{app}}/deleteuser" : "/loginappframework/apis/deleteuser.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
-    "/apps/{{app}}/updateuser" : "/loginappframework/apis/updateuser.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=true&addsToken=sub:{{{role}}},tokenflag:{{{tokenflag}}},id:{{{id}}},org:{{{org}}}&checkClaims=id,org",
-    "/apps/{{app}}/updateuserbyadmin" : "/loginappframework/apis/updateuser.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
+    "/apps/{{app}}/adduserbyadmin" : "/loginappframework/apis/adduserbyadmin.js?checksec_immediate=false&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
+    "/apps/{{app}}/deleteuser" : "/loginappframework/apis/deleteuser.js?checksec_immediate=false&get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
+    "/apps/{{app}}/updateuser" : "/loginappframework/apis/updateuser.js?checksec_immediate=false&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=true&addsToken=sub:{{{role}}},tokenflag:{{{tokenflag}}},id:{{{id}}},org:{{{org}}}&checkClaims=id,org",
+    "/apps/{{app}}/updateuserbyadmin" : "/loginappframework/apis/updateuser.js?checksec_immediate=false&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
     "/apps/{{app}}/changepassword" : "/loginappframework/apis/changepassword.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=true&checkClaims=id",
     "/apps/{{app}}/validatetotp" : "/loginappframework/apis/validatetotp.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=true",
     "/apps/{{app}}/gettotpsec" : "/loginappframework/apis/gettotpsec.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=true&checkClaims=id",
@@ -22,8 +22,8 @@
     "/apps/{{app}}/approveuser" : "/loginappframework/apis/approveuser.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
     "/apps/{{app}}/getorgsmatching" : "/loginappframework/apis/getorgsmatching.js?get=true&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=false",
     "/apps/{{app}}/verifyemail" : "/loginappframework/apis/verifyemail.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=false",
-    "/apps/{{app}}/addorupdateorg" : "/loginappframework/apis/addorupdateorg.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org&addsToken=sub:{{{role}}},tokenflag:{{{result}}},id:{{{id}}},org:{{{org}}}",
-    "/apps/{{app}}/orgkeys" : "/loginappframework/apis/orgkeys.js?keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
+    "/apps/{{app}}/addorupdateorg" : "/loginappframework/apis/addorupdateorg.js?checksec_immediate=false&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org&addsToken=sub:{{{role}}},tokenflag:{{{result}}},id:{{{id}}},org:{{{org}}}",
+    "/apps/{{app}}/orgkeys" : "/loginappframework/apis/orgkeys.js?checksec_immediate=false&keys=fheiwu98237hjief8923ydewjidw834284hwqdnejwr79389&needsToken=admin&checkClaims=org",
 
 
     

--- a/frontend/apps/loginapp/loginappframework/js/constants.mjs
+++ b/frontend/apps/loginapp/loginappframework/js/constants.mjs
@@ -78,14 +78,14 @@ export const APP_CONSTANTS = {
             LOGINAPP_PATH+"/main.html", LOGINAPP_PATH+"/reset.html", LOGINAPP_PATH+"/initiallogin.html", 
             LOGINAPP_PATH+"/register.html", LOGINAPP_PATH+"/notapproved.html", 
             LOGINAPP_PATH+"/loginroom.html", LOGINAPP_PATH+"/login.html",  LOGINAPP_PATH+"/reroute.html", $$.MONKSHU_CONSTANTS.ERROR_HTML,
-            `${EMBEDDED_APP_PATH}/*.html`],
+            `${EMBEDDED_APP_PATH}/[^/]+\\.html`, `${EMBEDDED_APP_PATH}/pages/[^/]+\\.html`, `${EMBEDDED_APP_PATH}/dialogs/[^/]+\\.html`],
 
         admin:[window.location.origin, LOGINAPP_PATH+"/index.html", LOGINAPP_PATH+"/download.html", 
             LOGINAPP_PATH+"/error.html", LOGINAPP_PATH+"/verify.html", LOGINAPP_PATH+"/main.html", 
             LOGINAPP_PATH+"/reset.html", LOGINAPP_PATH+"/initiallogin.html", LOGINAPP_PATH+"/register.html", 
             LOGINAPP_PATH+"/notapproved.html", LOGINAPP_PATH+"/loginroom.html", LOGINAPP_PATH+"/login.html", LOGINAPP_PATH+"/reroute.html", 
             LOGINAPP_PATH+"/manage.html", $$.MONKSHU_CONSTANTS.ERROR_HTML, 
-            `${EMBEDDED_APP_PATH}/*.html`],
+            `${EMBEDDED_APP_PATH}/[^/]+\\.html`, `${EMBEDDED_APP_PATH}/pages/[^/]+\\.html`, `${EMBEDDED_APP_PATH}/dialogs/[^/]+\\.html`],
 
         guest:[window.location.origin, LOGINAPP_PATH+"/index.html", LOGINAPP_PATH+"/download.html", 
             LOGINAPP_PATH+"/error.html", LOGINAPP_PATH+"/verify.html", LOGINAPP_PATH+"/reset.html", 


### PR DESCRIPTION
### Fix 1 — Default Screen Not Visible After Login

**Issue:** Post-login default screen (name, email, profile fields) not rendering — blank screen after login.

**Root Cause:** `PERMISSIONS_MAP` used `*.html` glob pattern which is invalid regex — framework's securityguard evaluates permissions as `RegExp`, so `*.html` never matched any path, silently blocking `pages/showeditprofile.html` from loading.

**Fix:** Replaced `*.html` with correct regex patterns `pages/[^/]+\.html` and `dialogs/[^/]+\.html` for `user` and `admin` roles. Default screen now renders correctly with all profile fields.

---

### Fix 2 — Post-login/admin functionality was failing

**Root Cause:** In the latest Monkshu, immediate security checks run at connection time; for certain claim-checked loginapp APIs, that happened before request data was fully available, causing valid requests to fail.

**Fix:** Added checksec_immediate=false to the affected loginapp APIs so security checks run after request data is available; the tested flows are now working.

**Testing Done:**
- Default screen is visible now after login
- All functionality also working

**Previous**(Default screen was not visible):
<img width="1281" height="927" alt="Previous" src="https://github.com/user-attachments/assets/39c1cf17-b4a6-458c-939e-7ca2aac67e16" />

### **After Fix**(Default screen visible and functionality is working too):
<img width="1834" height="949" alt="After" src="https://github.com/user-attachments/assets/d89145e5-7db3-4f60-96ea-07eadefde221" />
<img width="1834" height="949" alt="Screenshot from 2026-04-16 17-03-49" src="https://github.com/user-attachments/assets/2922e598-367c-42a5-8baa-1e09eb6461a6" />


**Mantis Link:** https://tekmonks.mantishub.io/app/issues/6010
