### PR TITLE
[FIX]: veto did not block JWT, login response leaked the users row

### DIFF
--- a/backend/apps/loginapp/loginappframework/apis/login.js
+++ b/backend/apps/loginapp/loginappframework/apis/login.js
@@ -123,8 +123,10 @@ const _informLoginListeners = async result => {
 	const loginlisteners = CLUSTER_MEMORY.get(LOGIN_LISTENERS_MEMORY_KEY, []);
 	for (const listener of loginlisteners) {
 		const listenerFunction = require(listener.modulePath)[listener.functionName];
-		if (!(await listenerFunction(result))) return false; return true; 
+        const listenerFunctionResult = await listenerFunction(result);
+		if (!listenerFunctionResult) return false; 
 	}
+    return true;
 }
 
 const validateRequest = jsonReq => jsonReq && jsonReq.pwph && jsonReq.id && (jsonReq?.dma === true || jsonReq.otp !== undefined);

--- a/backend/apps/loginapp/loginappframework/apis/login.js
+++ b/backend/apps/loginapp/loginappframework/apis/login.js
@@ -64,8 +64,9 @@ exports.doService = async (jsonReq, servObject) => {
 		LOG.error(`${result.reason == REASONS.BAD_ID?"Bad id":result.reason == REASONS.BAD_PASSWORD?"Bad password":"Unknown reason for login failure"} for login request for ID: ${jsonReq.id}.`);
 	}
 
+	const keysBeforeListeners = Object.keys(result);	// anything a listener adds below is meant for the UI, so it is returned
 	if (result.tokenflag && (!(await _informLoginListeners(result)))) {	// inform login listeners and give them a chance to veto the login
-		tokenflag = false; result.result = false; 
+		result.tokenflag = false; result.result = false;
 		if (result.reason == REASONS.OK || (!result.reason)) result.reason = REASONS.UNKNOWN;	// if the listener didn't add a reason for veto, then make the reason unknown
 	}
 
@@ -73,13 +74,15 @@ exports.doService = async (jsonReq, servObject) => {
 		LOG.info(`User logged in: ${result.id}${APP_CONSTANTS.CONF.verify_email_on_registeration?`, email verification status is ${result.verified}.`:"."}`); 
 		const remoteIP = utils.getClientIP(servObject.req);	// api end closes the socket so when the queue task runs remote IP is lost.
 		queueExecutor.add(async _=>{	// update login stats don't care much if it fails
-			try { await userid.updateLoginStats(jsonReq.id, Date.now(), remoteIP), undefined, true, 
-				APP_CONSTANTS.CONF.login_update_delay||DEFAULT_QUEUE_DELAY } 
+			try { await userid.updateLoginStats(jsonReq.id, Date.now(), remoteIP); }
 			catch(err) {LOG.error(`Error updating login stats for ID ${jsonReq.id}. Error is ${err}.`);}
-		});	
+		}, undefined, true, APP_CONSTANTS.CONF.login_update_delay||DEFAULT_QUEUE_DELAY);
 	} else LOG.error(`Bad login or not approved for ID: ${jsonReq.id}.`);
 
-	return {...result, verified: result.verified==1?true:false};
+	if (!result.tokenflag) return {result: false, reason: result.reason};
+
+	const listenerAdditions = Object.fromEntries(Object.entries(result).filter(([key]) => !keysBeforeListeners.includes(key)));
+	return {result: true, tokenflag: true, id: result.id, name: result.name, org: result.org, role: result.role, totpsec: result.totpsec, verified: result.verified==1?true:false, ...listenerAdditions};
 }
 
 exports.getID = headers => {


### PR DESCRIPTION
## Updates

Three fixes to `loginappframework/apis/login.js`:

1. `_informLoginListeners` - moved `return true` out of the loop body.
2. Login veto - `tokenflag = false` → `result.tokenflag = false`.
3. Login response - return an explicit set of fields instead of `{...result}`.
4. `queueExecutor.add` - trailing args moved out of the task closure into the arg list.


## Why the updates were made

**1.** `return true` sat inside the `for` loop, so only the first listener ever ran, and an empty list returned `undefined`, which read as a veto.

**2.** The missing `result.` prefix left `result.tokenflag` true. The framework reads that flag to decide whether to sign a JWT, so vetoed logins still got a working token.

**3.** `checkPWPH` spreads the whole `users` row, so `{...result}` shipped the bcrypt hash to the browser. Now only what the UI and JWT claims read goes back; listener-added fields are diffed back in.

**4.** The trailing args sat inside the closure, so `add` got one argument: `isAsync` stayed false (unawaited stats writes interleave) and `delay` stayed 0, making `login_update_delay` dead.

## Testing Screenshots 
- Attached in the mantis given below.
- Mantis Link - https://tekmonks.mantishub.io/app/issues/6848